### PR TITLE
[GRDM-30807] GRDM rdm.nii.ac.jpへの対応

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tljh-repo2docker",
-    version="0.0.1",
+    version="0.0.2",
     entry_points={"tljh": ["tljh_repo2docker = tljh_repo2docker"]},
     packages=find_packages(),
     include_package_data=True,

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from aiodocker import Docker
@@ -390,21 +391,25 @@ def tljh_custom_jupyterhub_config(c):
         'rdm': RDMProvider,
         'weko3': WEKO3Provider,
     }
-    c.RDMProvider.hosts = [
+    rdm_provider_hosts = [
         {
             'hostname': ["https://osf.io/"],
             'api': "https://api.osf.io/v2/"
         },
         {
-            'hostname': ["https://bh.rdm.yzwlab.com/"],
-            'api': "https://api.bh.rdm.yzwlab.com/v2/",
+            'hostname': ["https://rdm.nii.ac.jp"],
+            'api': "https://api.rdm.nii.ac.jp/v2/",
         },
         {
             'hostname': ["https://rcos.rdm.nii.ac.jp"],
             'api': "https://api.rcos.rdm.nii.ac.jp/v2/",
         },
     ]
-    
+    custom_hosts = os.environ.get('REPO2DOCKER_RDM_PROVIDER_HOSTS', None)
+    if custom_hosts is not None:
+        rdm_provider_hosts = json.loads(custom_hosts)
+    c.RDMProvider.hosts = rdm_provider_hosts
+
     # register the handlers to manage the user images
     c.JupyterHub.extra_handlers.extend(
         [


### PR DESCRIPTION
tljh-repo2dockerでrdm.nii.ac.jpからイメージをビルドできるよう、設定を変更しました。

また、GRDMのAPIエンドポイント一覧をカスタマイズできるよう、 `REPO2DOCKER_RDM_PROVIDER_HOSTS` 環境変数を追加しました。この環境変数に、repo2dockerの `c.RDMProvider.hosts`パラメータを与えることでGRDMのURLとAPIエンドポイントの対応関係を変更することができます。

例: GRDM本番系からのビルドのみを許可する

```
$ sudo cat /etc/systemd/system/jupyterhub.service
[sudo] password for ubuntu: 
# Template file for JupyterHub systemd service
# Uses simple string.format() for 'templating'
[Unit]
# Traefik must have successfully started *before* we launch JupyterHub
Requires=traefik.service
After=traefik.service

[Service]
User=root
Restart=always
WorkingDirectory=/opt/tljh/state
# Protect bits that are normally shared across the system
PrivateTmp=yes
PrivateDevices=yes
ProtectKernelTunables=yes
ProtectKernelModules=yes
Environment=TLJH_INSTALL_PREFIX=/opt/tljh
# ここを追加
Environment='REPO2DOCKER_RDM_PROVIDER_HOSTS=[{"hostname":["https://rdm.nii.ac.jp"],"api":"https://api.rdm.nii.ac.jp/v2/"}]'
# /ここを追加
# Run upgrade-db before starting, in case Hub version has changed
# This is a no-op when no db exists or no upgrades are needed
ExecStart=/opt/tljh/hub/bin/python3 -m jupyterhub.app -f /opt/tljh/hub/lib/python3.8/site-packages/tljh/jupyterhub_config.py --upgrade-db

[Install]
# Start service when system boots
WantedBy=multi-user.target

```