### PR TITLE
[GRDM-44131] CS-repo2docker更新 2025.01.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           python -m build .
 
       - name: Upload package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tljh_repo2docker-artifacts
           path: |
@@ -47,7 +47,7 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tljh_repo2docker-artifacts
 
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.10', '3.11']
 
     steps:
       - name: Checkout
@@ -80,7 +80,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Download app package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tljh_repo2docker-artifacts
 
@@ -120,7 +120,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Download app package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tljh_repo2docker-artifacts
 
@@ -129,6 +129,12 @@ jobs:
           set -eux
           python -m pip install -r dev-requirements.txt
           python -m pip install tljh_repo2docker*.whl
+
+          # Workaround: upgrade to the latest version of jupyterhub
+          # Because an older version of jupyterhub is installed together with CS-binderhub,
+          # upgrade jupyterhub after the installation of the plugin
+          python -m pip install --upgrade jupyterhub\<5
+
           npm -g install configurable-http-proxy
 
       - name: Install UI test dependencies
@@ -155,9 +161,9 @@ jobs:
 
       - name: Upload Playwright Test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tljh-playwright-tests
+          name: tljh-playwright-tests-${{ matrix.build-backend }}
           path: |
             ui-tests/local-test-results
             ui-tests/binderhub-test-results

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -22,7 +22,7 @@ jobs:
           version_spec: next
 
       - name: Upload Distributions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tljh_repo2docker-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/README-ja.md
+++ b/README-ja.md
@@ -33,7 +33,7 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2024.10.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2025.01.0
 sudo docker pull gcr.io/nii-ap-ops/rdmfs:2024.12.0
 
 # install TLJH 1.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2024.10.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2025.01.0
 sudo docker pull gcr.io/nii-ap-ops/rdmfs:2024.12.0
 
 # install TLJH 1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub@1.0.0
-git+https://github.com/jupyterhub/binderhub.git@main
-jupyterhub>=4,<5
+git+https://github.com/RCOSDP/CS-binderhub.git@master
+jupyterhub>=4
 alembic>=1.13.0,<1.14
 pytest
 pytest-aiohttp

--- a/src/environments/EnvironmentList.tsx
+++ b/src/environments/EnvironmentList.tsx
@@ -31,10 +31,10 @@ const columns: GridColDef[] = [
     headerName: 'Reference',
     maxWidth: 150,
     renderCell: params => {
-      return (
-        params.row.provider === 'rdm'
-          ? '-'
-          : <a href={`${params.row.repo}/tree/${params.value}`}>{params.value}</a>
+      return params.row.provider === 'rdm' ? (
+        '-'
+      ) : (
+        <a href={`${params.row.repo}/tree/${params.value}`}>{params.value}</a>
       );
     }
   },

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -393,7 +393,7 @@ if hookimpl:
             "dockerspawner~=12.1",
             "jupyter_client~=6.1,<8",
             "aiodocker~=0.19",
-            "git+https://github.com/RCOSDP/CS-binderhub.git",
+            "git+https://github.com/RCOSDP/CS-binderhub.git@master",
         ]
 
 else:

--- a/tljh_repo2docker/launcher.py
+++ b/tljh_repo2docker/launcher.py
@@ -71,7 +71,7 @@ class LaunchHandler(BaseHandler):
         await build_image(
             repo, ref, '', memory, cpu, username, password, [],
             default_image_name=image_name,
-            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2024.10.0',
+            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2025.01.0',
             optional_envs=provider.get_optional_envs(access_token=repo_token),
             optional_labels=optional_labels,
         )

--- a/tljh_repo2docker/tests/local_build/test_builder.py
+++ b/tljh_repo2docker/tests/local_build/test_builder.py
@@ -10,8 +10,11 @@ async def test_add_environment(app, minimal_repo, image_name):
     r = await add_environment(app, repo=minimal_repo, name=name, ref=ref)
     assert r.status_code == 200
     image = await wait_for_image(image_name=image_name)
+    image_config = image.get("ContainerConfig", None)
+    if image_config is None:
+        image_config = image.get("Config", {})
     assert (
-        image["ContainerConfig"]["Labels"]["tljh_repo2docker.image_name"] == image_name
+        image_config["Labels"]["tljh_repo2docker.image_name"] == image_name
     )
 
 
@@ -41,8 +44,11 @@ async def test_uppercase_repo(app, minimal_repo_uppercase, generated_image_name)
     r = await add_environment(app, repo=minimal_repo_uppercase)
     assert r.status_code == 200
     image = await wait_for_image(image_name=generated_image_name)
+    image_config = image.get("ContainerConfig", None)
+    if image_config is None:
+        image_config = image.get("Config", {})
     assert (
-        image["ContainerConfig"]["Labels"]["tljh_repo2docker.image_name"]
+        image_config["Labels"]["tljh_repo2docker.image_name"]
         == generated_image_name
     )
 

--- a/ui-tests/tests/ui.test.ts
+++ b/ui-tests/tests/ui.test.ts
@@ -98,9 +98,12 @@ test.describe('tljh_repo2docker UI Tests', () => {
       .getByRole('button')
       .first()
       .click();
-    await page.waitForSelector('span:has-text("Successfully tagged")', {
-      timeout: 600000
-    });
+    await page.waitForSelector(
+      '//span[contains(text(), "Successfully tagged") or (contains(text(), "naming to ") and contains(text(), " done"))]',
+      {
+        timeout: 600000
+      }
+    );
     expect(await page.screenshot()).toMatchSnapshot('environment-console.png', {
       maxDiffPixelRatio: 0.05
     });


### PR DESCRIPTION
CS-repo2dockerを最新版 2025.01.0 https://github.com/RCOSDP/CS-repo2docker/releases/tag/2025.01.0 に更新しました。

https://github.com/RCOSDP/CS-binderhub の更新にともない、Ubuntu 24.04でも動作することを確認しました。
