### PR TITLE
[GRDM-55309] GRDMコンテンツの部分取り込み・遅延取り込みへの対応

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -33,8 +33,8 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2025.01.0
-sudo docker pull gcr.io/nii-ap-ops/rdmfs:2024.12.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2025.10.0
+sudo docker pull gcr.io/nii-ap-ops/rdmfs:2025.10.0
 
 # install TLJH 1.0
 curl -L https://tljh.jupyter.org/bootstrap.py \

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2025.01.0
-sudo docker pull gcr.io/nii-ap-ops/rdmfs:2024.12.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2025.10.0
+sudo docker pull gcr.io/nii-ap-ops/rdmfs:2025.10.0
 
 # install TLJH 1.0
 curl -L https://tljh.jupyter.org/bootstrap.py \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub@1.0.0
-git+https://github.com/RCOSDP/CS-binderhub.git@master
+git+https://github.com/RCOSDP/CS-binderhub.git@2025.11.0
+git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
 jupyterhub>=4
 alembic>=1.13.0,<1.14
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "sqlalchemy>=2",
   "pydantic>=2,<3",
   "alembic>=1.13,<2",
-  "jupyter-repo2docker>=2024,<2025",
+  "jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0",
   "aiosqlite~=0.19.0",
 ]
 dynamic = ["version"]
@@ -24,6 +24,9 @@ tljh_repo2docker_upgrade_db = "tljh_repo2docker.dbutil:main"
 
 [project.entry-points.tljh]
 tljh_repo2docker = "tljh_repo2docker"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 source = "nodejs"

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -1,5 +1,6 @@
 import json
 import os
+import textwrap
 
 from aiodocker import Docker
 from aiodocker.exceptions import DockerError
@@ -28,6 +29,26 @@ CPU_PERIOD = 100_000
 
 TLJH_R2D_ADMIN_SCOPE = "custom:tljh_repo2docker:admin"
 
+
+PROVISION_WRAPPER_CMD = textwrap.dedent("""\
+set -e
+
+# Find and execute provision.sh if it exists
+for path in \
+    "${REPO_DIR}/binder/provision.sh" \
+    "${REPO_DIR}/.binder/provision.sh" \
+    "$HOME/binder/provision.sh" \
+    "$HOME/.binder/provision.sh"; do
+
+    if [ -f "$path" ]; then
+        echo "[provision-wrapper] Executing: $path" >&2
+        exec bash "$path" jupyterhub-singleuser
+    fi
+done
+
+# No provision.sh found, start normally
+exec jupyterhub-singleuser
+""").strip()
 
 class SpawnerMixin(Configurable):
     """
@@ -223,6 +244,8 @@ class SpawnerMixin(Configurable):
         mount_path = os.path.join(self.rdmfs_base_path, self.container_name)
         if not os.path.exists(mount_path):
             os.makedirs(mount_path)
+        # Allow jovyan user to create symlinks in /mnt for provision.sh
+        os.chmod(mount_path, 0o777)
         self.extra_mounts = [
             dict(type='bind', source=mount_path, target='/mnt', propagation='rshared'),
         ]
@@ -230,14 +253,11 @@ class SpawnerMixin(Configurable):
         if rdmfs_id is not None:
             await self.remove_object_by_id(rdmfs_id)
         rdmfs_id = await self.create_rdmfs_object({
-            'RDM_NODE_ID': labels.get(
-                "tljh_repo2docker.opt.user.rdm_node_id", None
-            ),
             'RDM_API_URL': labels.get(
                 "tljh_repo2docker.opt.user.rdm_api_url", None
             ),
             'RDM_TOKEN': repo_token,
-            'MOUNT_PATH': '/mnt/rdm',
+            'MOUNT_PATH': '/mnt/rdms',
         })
         await self.start_object_by_id(rdmfs_id)
 
@@ -305,7 +325,7 @@ class SpawnerMixin(Configurable):
                 desc = await obj.show()
                 if 'State' in desc and desc['State']['Running']:
                     self.log.info('terminating...')
-                    exec = await obj.exec(["/bin/sh","-c","xattr -w command terminate /mnt/rdm"])
+                    exec = await obj.exec(["/bin/sh","-c","xattr -w command terminate /mnt/rdms"])
                     result = await exec.start(detach=True)
                     self.log.info('terminated: {}'.format(result))
                 else:
@@ -368,7 +388,7 @@ if hookimpl:
         c.JupyterHub.spawner_class = Repo2DockerSpawner
 
         # spawner
-        c.DockerSpawner.cmd = ["jupyterhub-singleuser"]
+        c.DockerSpawner.cmd = ["bash", "-lc", PROVISION_WRAPPER_CMD]
         c.DockerSpawner.pull_policy = "Never"
         c.DockerSpawner.remove = True
         c.Repo2DockerSpawner.rdmfs_base_path = '/opt/tljh/repo2docker/volumes'

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -300,7 +300,7 @@ class SpawnerMixin(Configurable):
             Privileged=True,
         )
         create_kwargs = dict(
-            Image='gcr.io/nii-ap-ops/rdmfs:2024.12.0',
+            Image='gcr.io/nii-ap-ops/rdmfs:2025.10.0',
             Env=[f'{k}={v}' for k, v in env.items()],
             AutoRemove=True,
             HostConfig=host_config,
@@ -413,7 +413,7 @@ if hookimpl:
             "dockerspawner~=12.1",
             "jupyter_client~=6.1,<8",
             "aiodocker~=0.19",
-            "git+https://github.com/RCOSDP/CS-binderhub.git@master",
+            "git+https://github.com/RCOSDP/CS-binderhub.git@2025.11.0",
         ]
 
 else:

--- a/tljh_repo2docker/launcher.py
+++ b/tljh_repo2docker/launcher.py
@@ -76,7 +76,7 @@ class LaunchHandler(BaseHandler):
         await build_image(
             repo, ref, '', memory, cpu, username, password, [],
             default_image_name=image_name,
-            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2025.01.0',
+            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2025.10.0',
             optional_envs=provider.get_optional_envs(access_token=repo_token),
             optional_labels=optional_labels,
         )

--- a/tljh_repo2docker/launcher.py
+++ b/tljh_repo2docker/launcher.py
@@ -32,6 +32,11 @@ class LaunchHandler(BaseHandler):
         spec = self._get_spec_from_request(provider_prefix)
         spec = spec.rstrip("/")
         provider = self._get_provider(provider_prefix, spec)
+
+        repo_token = self.get_argument('repo_token', None)
+        if repo_token and hasattr(provider, "set_access_token"):
+            provider.set_access_token(repo_token)
+
         repo = provider.get_repo_url()
         ref = await provider.get_resolved_ref()
 
@@ -48,7 +53,7 @@ class LaunchHandler(BaseHandler):
         buildargs = None
         username = None
         password = None
-        repo_token = self.get_argument('repo_token', None)
+        # repo_token is obtained above to authenticate provider access
         urlpath = self.get_argument('urlpath', None)
         if not repo:
             raise web.HTTPError(400, "Repository is empty")

--- a/tljh_repo2docker/tests/local_build/test_logs.py
+++ b/tljh_repo2docker/tests/local_build/test_logs.py
@@ -15,7 +15,9 @@ async def test_stream_simple(app, minimal_repo, image_name):
     ex = async_requests.executor
     line_iter = iter(r.iter_lines(decode_unicode=True))
     evt = await ex.submit(next_event, line_iter)
-    assert evt == {"phase": "log", "message": "Picked Git content provider.\n"}
+    # CS-repo2docker may output additional logs (e.g., Dataverse initialization) before the Git provider message
+    assert evt["phase"] == "log"
+    assert "Picked Git content provider.\n" in evt["message"]
 
     r.close()
     await wait_for_image(image_name=image_name)


### PR DESCRIPTION
CS-rdmfs の全プロジェクトマウント機能と CS-repo2docker の provision.sh に対応し、GRDMコンテンツの部分取り込み・遅延取り込みを可能にしました。

## 主な変更

### CS-rdmfs 全プロジェクトマウント対応

  - マウントパスを `/mnt/rdm` から `/mnt/rdms` に変更
  - `RDM_NODE_ID` 環境変数を削除（全プロジェクトモード対応）
  - `/mnt` ディレクトリのパーミッションを調整し、jovyan ユーザーがシンボリックリンクを作成可能に(`/mnt/rdm`の作成)

 ### provision.sh 統合

  CS-repo2docker の RDM ContentProvider が生成する provision.sh スクリプトを自動実行するラッパーを追加しました。これにより、以下が可能になります：

- RDM ストレージからのデータコピー/リンク処理の自動化（部分取り込み）
- バックグラウンド実行によるJupyter起動タイムアウト回避（遅延取り込み）
- `/tmp/provision.log` でのプロビジョニング進捗確認

 ### イメージ再利用機能の追加

既に同じタグのイメージが存在する場合、再ビルドをスキップしてラベルのみ更新する機能を追加しました。これによりビルド時間を短縮できます。
