### PR TITLE
[GRDM-55309] repo2docker 2025.12.0 への更新と BINDER_REPO_URL 対応

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -33,7 +33,7 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2025.10.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2025.12.0
 sudo docker pull gcr.io/nii-ap-ops/rdmfs:2025.10.0
 
 # install TLJH 1.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2025.10.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2025.12.0
 sudo docker pull gcr.io/nii-ap-ops/rdmfs:2025.10.0
 
 # install TLJH 1.0

--- a/tljh_repo2docker/launcher.py
+++ b/tljh_repo2docker/launcher.py
@@ -76,7 +76,7 @@ class LaunchHandler(BaseHandler):
         await build_image(
             repo, ref, '', memory, cpu, username, password, [],
             default_image_name=image_name,
-            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2025.10.0',
+            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2025.12.0',
             optional_envs=provider.get_optional_envs(access_token=repo_token),
             optional_labels=optional_labels,
         )


### PR DESCRIPTION
repo2docker を 2025.12.0 に更新し、BINDER_REPO_URL 環境変数のサポートを追加しました。

## 主な変更

### repo2docker 2025.12.0 への更新

- `gcr.io/nii-ap-ops/repo2docker:2025.12.0` を使用するよう更新
- README の docker pull コマンドも更新

### BINDER_REPO_URL 環境変数のサポート

Spawner 起動時にイメージラベル (`repo2docker.repo`) から `BINDER_REPO_URL` 環境変数を自動設定するようにしました。これにより、コンテナ内から元のリポジトリ URL を参照できます。

- RDM プロバイダーでラベルが存在しない場合はエラー
- その他のプロバイダーでは警告ログを出力