### PR TITLE
Update repo2docker to 2026.02.0 and rdmfs to 2026.02.1

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -33,8 +33,8 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2025.12.0
-sudo docker pull gcr.io/nii-ap-ops/rdmfs:2025.10.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.02.0
+sudo docker pull gcr.io/nii-ap-ops/rdmfs:2026.02.1
 
 # install TLJH 1.0
 curl -L https://tljh.jupyter.org/bootstrap.py \

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2025.12.0
-sudo docker pull gcr.io/nii-ap-ops/rdmfs:2025.10.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.02.0
+sudo docker pull gcr.io/nii-ap-ops/rdmfs:2026.02.1
 
 # install TLJH 1.0
 curl -L https://tljh.jupyter.org/bootstrap.py \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub@1.0.0
-git+https://github.com/RCOSDP/CS-binderhub.git@2025.11.0
+git+https://github.com/RCOSDP/CS-binderhub.git@2026.02.0
 git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
 jupyterhub>=4
 alembic>=1.13.0,<1.14

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub@1.0.0
 git+https://github.com/RCOSDP/CS-binderhub.git@2025.11.0
-git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
 jupyterhub>=4
 alembic>=1.13.0,<1.14
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "sqlalchemy>=2",
   "pydantic>=2,<3",
   "alembic>=1.13,<2",
-  "jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0",
+  "jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0",
   "aiosqlite~=0.19.0",
 ]
 dynamic = ["version"]

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -300,7 +300,7 @@ class SpawnerMixin(Configurable):
             Privileged=True,
         )
         create_kwargs = dict(
-            Image='gcr.io/nii-ap-ops/rdmfs:2025.10.0',
+            Image='gcr.io/nii-ap-ops/rdmfs:2026.02.1',
             Env=[f'{k}={v}' for k, v in env.items()],
             AutoRemove=True,
             HostConfig=host_config,

--- a/tljh_repo2docker/launcher.py
+++ b/tljh_repo2docker/launcher.py
@@ -76,7 +76,7 @@ class LaunchHandler(BaseHandler):
         await build_image(
             repo, ref, '', memory, cpu, username, password, [],
             default_image_name=image_name,
-            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2025.12.0',
+            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2026.02.0',
             optional_envs=provider.get_optional_envs(access_token=repo_token),
             optional_labels=optional_labels,
         )


### PR DESCRIPTION
repo2dockerを2026.02.0に、rdmfsを2026.02.1に更新しました。

# 主な変更

## 利用するDockerイメージおよびライブラリの更新

+ repo2docker -- `gcr.io/nii-ap-ops/repo2docker:2026.02.0` を使用するように更新
+ rdmfs -- `gcr.io/nii-ap-ops/rdmfs:2026.02.1` を使用するように更新
+ README.md と README-ja.md に記載の `docker pull` コマンドも更新

## 依存するライブラリの更新

+ repo2docker -- `CS-repo2docker@2026.02.0` に更新
+ binderhub -- `CS-binderhub@2026.02.0`に更新

# 備考

#11 で発見された問題を、rdmfsのDockerイメージを新たにすることで解消したPRです。