### PR TITLE
[GRDM-58288]chardetのバージョンアップに伴うCS-tljh-reop2dockerのマージ時のテスト失敗への対応

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ npm -g install configurable-http-proxy
 User environments are built with `repo2docker` running in a Docker container. To pull the Docker image:
 
 ```bash
-docker pull quay.io/jupyterhub/repo2docker:main
+docker pull gcr.io/nii-ap-ops/repo2docker:2026.02.0
 ```
 
 ## Run

--- a/tljh_repo2docker/docker.py
+++ b/tljh_repo2docker/docker.py
@@ -159,7 +159,7 @@ async def build_image(
 
     config = {
         "Cmd": cmd,
-        "Image": repo2docker_image or "quay.io/jupyterhub/repo2docker:main",
+        "Image": repo2docker_image or "gcr.io/nii-ap-ops/repo2docker:2026.02.0",
         "Labels": builder_labels,
         "Volumes": {
             "/var/run/docker.sock": {

--- a/tljh_repo2docker/tests/binderhub_build/test_logs.py
+++ b/tljh_repo2docker/tests/binderhub_build/test_logs.py
@@ -1,7 +1,7 @@
 import pytest
 from jupyterhub.tests.utils import async_requests
 
-from ..utils import add_environment, api_request, next_event, wait_for_image
+from ..utils import add_environment, api_request, find_event, wait_for_image
 
 
 @pytest.mark.asyncio
@@ -18,10 +18,14 @@ async def test_stream_simple(app, minimal_repo, image_name):
     assert r.headers["content-type"] == "text/event-stream"
     ex = async_requests.executor
     line_iter = iter(r.iter_lines(decode_unicode=True))
-    evt = await ex.submit(next_event, line_iter)
-    evt = await ex.submit(next_event, line_iter)
-    msg = evt.get("message", "")
-    assert "Picked Git content provider." in msg
+    # The build stream may contain warnings on stderr (e.g.,
+    # RequestsDependencyWarning) before the Git provider message.
+    evt = await ex.submit(
+        find_event,
+        line_iter,
+        lambda e: "Picked Git content provider." in e.get("message", ""),
+    )
+    assert evt["phase"] == "log"
 
     r.close()
     await wait_for_image(image_name=image_name)

--- a/tljh_repo2docker/tests/local_build/test_logs.py
+++ b/tljh_repo2docker/tests/local_build/test_logs.py
@@ -1,7 +1,7 @@
 import pytest
 from jupyterhub.tests.utils import async_requests
 
-from ..utils import add_environment, api_request, next_event, wait_for_image
+from ..utils import add_environment, api_request, find_event, wait_for_image
 
 
 @pytest.mark.asyncio
@@ -14,10 +14,14 @@ async def test_stream_simple(app, minimal_repo, image_name):
     assert r.headers["content-type"] == "text/event-stream"
     ex = async_requests.executor
     line_iter = iter(r.iter_lines(decode_unicode=True))
-    evt = await ex.submit(next_event, line_iter)
-    # CS-repo2docker may output additional logs (e.g., Dataverse initialization) before the Git provider message
+    # The build stream may contain warnings on stderr (e.g.,
+    # RequestsDependencyWarning) before the Git provider message.
+    evt = await ex.submit(
+        find_event,
+        line_iter,
+        lambda e: "Picked Git content provider." in e.get("message", ""),
+    )
     assert evt["phase"] == "log"
-    assert "Picked Git content provider.\n" in evt["message"]
 
     r.close()
     await wait_for_image(image_name=image_name)

--- a/tljh_repo2docker/tests/utils.py
+++ b/tljh_repo2docker/tests/utils.py
@@ -122,3 +122,21 @@ def next_event(it):
             return
         if line.startswith("data:"):
             return json.loads(line.split(":", 1)[1])
+
+
+def find_event(it, predicate, max_events=50):
+    """Scan SSE events until one satisfies predicate.
+
+    Skips non-matching events such as warnings on stderr before
+    repo2docker produces its real output.
+
+    Raises StopIteration if the stream ends or max_events is
+    reached without finding a match.
+    """
+    for _ in range(max_events):
+        evt = next_event(it)
+        if evt is None:
+            raise StopIteration("Stream ended without matching event")
+        if predicate(evt):
+            return evt
+    raise StopIteration(f"No matching event found within {max_events} events")


### PR DESCRIPTION
#12 のマージ時にテストが失敗した問題を、デフォルトのrepo2dockerイメージをCS-repo2docker(`gcr.io/nii-ap-ops/repo2docker:2026.02.0`)に変更することで修正します。同時に、失敗していたテストにおける成否の判定を修正しました。

## 問題の詳細

デフォルトのrepo2dockerイメージとしてupstreamのイメージ `quay.io/jupyterhub/repo2docker:main`を利用していましたが、このイメージが3月2日に更新され、`requests`ライブラリがインポート時に警告メッセージを出力するようになりました。この警告自体はテストやプログラムの実行を停止させるものではありませんが、 `tljh_repo2docker.tests.local_build.test_logs`モジュールで定義されるテストのうち、`test_stream_simple`はこのような警告メッセージの存在を想定していないため、期待されるメッセージが確認できずにテストが失敗していました。

なお、`requests`ライブラリが警告メッセージを出力するようになったのは、`requests`が`chardet`のバージョンとして6未満かをチェックしている一方でプロジェクト設定ファイルでバージョンを固定していない状況の中で、`chardet`のバージョン6(以上)がリリースされたためです。

## 本PRの提案

本PRは以下の2点によりこの問題を修正します。

1. デフォルトのrepo2dockerイメージとしてCS-repo2dockerのイメージを利用する
2. 失敗していたテストのロジックを修正する

本プロジェクトが依存関係において指定するCS-repo2dockerのイメージ`gcr.io/nii-ap-ops/repo2docker:2026.02.0`を指定しているので、デフォルトのrepo2dockerイメージとしてもこれを採用することは合理的であると考えられます。このイメージは `chardet`のバージョン6以降がリリースされる前に作られたイメージであるため`requests`のインポート時に警告メッセージを出力せず、テストの前提を破壊しません。

また、失敗していたテスト`tljh_repo2docker.tests.local_build.test_logs.test_stream_simple`はテスト時に特定のメッセージが先頭に表示されることを期待していましたが、これを修正してメッセージ中にそのメッセージが含まれているかを検証するロジックに変更しています。同様のロジックでテストしていた`tljh_repo2docker.tests.binderhub_build.test_logs.test_stream_simple`にも同様の修正を実施しました。