### PR TITLE
[GRDM-59575] Update repo2docker to 2026.06.0

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -33,7 +33,7 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.02.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.06.0
 sudo docker pull gcr.io/nii-ap-ops/rdmfs:2026.02.1
 
 # install TLJH 1.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.02.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.06.0
 sudo docker pull gcr.io/nii-ap-ops/rdmfs:2026.02.1
 
 # install TLJH 1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub@1.0.0
 git+https://github.com/RCOSDP/CS-binderhub.git@2026.02.0
-git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
+git+https://github.com/RCOSDP/CS-repo2docker.git@2026.06.0
 jupyterhub>=4
 alembic>=1.13.0,<1.14
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "sqlalchemy>=2",
   "pydantic>=2,<3",
   "alembic>=1.13,<2",
-  "jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0",
+  "jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.06.0",
   "aiosqlite~=0.19.0",
 ]
 dynamic = ["version"]

--- a/tljh_repo2docker/launcher.py
+++ b/tljh_repo2docker/launcher.py
@@ -76,7 +76,7 @@ class LaunchHandler(BaseHandler):
         await build_image(
             repo, ref, '', memory, cpu, username, password, [],
             default_image_name=image_name,
-            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2026.02.0',
+            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2026.06.0',
             optional_envs=provider.get_optional_envs(access_token=repo_token),
             optional_labels=optional_labels,
         )


### PR DESCRIPTION
repo2dockerを2026.06.0に更新しました。

# 変更

+ 利用するDockerイメージの更新
  + repo2docker -- `gcr.io/nii-ap-ops/repo2docker:2026.06.0` を使用するように更新
  + README.md と README-ja.md に記載の `docker pull` コマンドを更新
+ 依存するライブラリの更新
  + repo2docker -- `CS-repo2docker@2026.06.0` に更新

# 備考

R Studioを含む基本イメージからの解析環境の構築が失敗する件を修正するためのPRです。本PRのみで修正されます。

ただし、CS-binderhubの参照するrepo2dockerはまだ更新していないため、以下に挙げる4つのテストが失敗します。

+ Unit tests (3.10)
+ Unit tests (3.11)
+ Integration tests (local)
+ Integration tests (binderhub)

これを修正する[PR](https://github.com/RCOSDP/CS-binderhub/pull/28)をCS-binderhubに提出しています。