### PR TITLE
[GRDM-60339] Update repo2docker to 2026.07.2

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -33,7 +33,7 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.06.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.07.0
 sudo docker pull gcr.io/nii-ap-ops/rdmfs:2026.02.1
 
 # install TLJH 1.0

--- a/README-ja.md
+++ b/README-ja.md
@@ -33,7 +33,7 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.07.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.07.1
 sudo docker pull gcr.io/nii-ap-ops/rdmfs:2026.02.1
 
 # install TLJH 1.0

--- a/README-ja.md
+++ b/README-ja.md
@@ -33,7 +33,7 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.07.1
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.07.2
 sudo docker pull gcr.io/nii-ap-ops/rdmfs:2026.02.1
 
 # install TLJH 1.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.07.1
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.07.2
 sudo docker pull gcr.io/nii-ap-ops/rdmfs:2026.02.1
 
 # install TLJH 1.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.07.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.07.1
 sudo docker pull gcr.io/nii-ap-ops/rdmfs:2026.02.1
 
 # install TLJH 1.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo npm install -g yarn
 sudo modprobe fuse
 
 # pull the repo2docker image
-sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.06.0
+sudo docker pull gcr.io/nii-ap-ops/repo2docker:2026.07.0
 sudo docker pull gcr.io/nii-ap-ops/rdmfs:2026.02.1
 
 # install TLJH 1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub@1.0.0
-git+https://github.com/RCOSDP/CS-binderhub.git@2026.06.0
-git+https://github.com/RCOSDP/CS-repo2docker.git@2026.06.0
+git+https://github.com/RCOSDP/CS-binderhub.git@2026.07.0
+git+https://github.com/RCOSDP/CS-repo2docker.git@2026.07.2
 jupyterhub>=4
 alembic>=1.13.0,<1.14
 pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub@1.0.0
-git+https://github.com/RCOSDP/CS-binderhub.git@2026.02.0
+git+https://github.com/RCOSDP/CS-binderhub.git@2026.06.0
 git+https://github.com/RCOSDP/CS-repo2docker.git@2026.06.0
 jupyterhub>=4
 alembic>=1.13.0,<1.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "sqlalchemy>=2",
   "pydantic>=2,<3",
   "alembic>=1.13,<2",
-  "jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.06.0",
+  "jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.07.2",
   "aiosqlite~=0.19.0",
 ]
 dynamic = ["version"]

--- a/tljh_repo2docker/launcher.py
+++ b/tljh_repo2docker/launcher.py
@@ -76,7 +76,7 @@ class LaunchHandler(BaseHandler):
         await build_image(
             repo, ref, '', memory, cpu, username, password, [],
             default_image_name=image_name,
-            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2026.07.1',
+            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2026.07.2',
             optional_envs=provider.get_optional_envs(access_token=repo_token),
             optional_labels=optional_labels,
         )

--- a/tljh_repo2docker/launcher.py
+++ b/tljh_repo2docker/launcher.py
@@ -76,7 +76,7 @@ class LaunchHandler(BaseHandler):
         await build_image(
             repo, ref, '', memory, cpu, username, password, [],
             default_image_name=image_name,
-            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2026.07.0',
+            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2026.07.1',
             optional_envs=provider.get_optional_envs(access_token=repo_token),
             optional_labels=optional_labels,
         )

--- a/tljh_repo2docker/launcher.py
+++ b/tljh_repo2docker/launcher.py
@@ -76,7 +76,7 @@ class LaunchHandler(BaseHandler):
         await build_image(
             repo, ref, '', memory, cpu, username, password, [],
             default_image_name=image_name,
-            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2026.06.0',
+            repo2docker_image='gcr.io/nii-ap-ops/repo2docker:2026.07.0',
             optional_envs=provider.get_optional_envs(access_token=repo_token),
             optional_labels=optional_labels,
         )


### PR DESCRIPTION
repo2dockerを2026.07.2に更新しました。

# 変更

+ 利用するDockerイメージの更新
  + repo2docker -- `gcr.io/nii-ap-ops/repo2docker:2026.07.2` を使用するように更新
  + README.md と README-ja.md に記載の `docker pull` コマンドを更新
+ 依存するライブラリの更新
  + binderhub -- `CS-binderhub@2026.07.0` に更新
  + repo2docker -- `CS-repo2docker@2026.07.2` に更新(dev-requirements.txt, pyproject.toml)

# 備考

CS-repo2docker 2026.07.2 は、RStudio Serverの最新安定版インストールと rstudio.yml によるバージョン指定(2026.07.0)に、ワイルドカード形式のRバージョン指定でビルドが失敗する問題の修正(RCOSDP/CS-repo2docker#29)と、CS-jupyter-resource-usage のソースビルドが失敗するようになった問題への対処(RCOSDP/CS-repo2docker#30)を加えたリリースです。
https://github.com/RCOSDP/CS-repo2docker/releases/tag/2026.07.2

CS-binderhub 2026.07.0 は CS-repo2docker 2026.07.2 を参照するタグで、figshare の DOI からの起動ができない問題の修正(GRDM-61282, RCOSDP/CS-binderhub#29)を含みます。